### PR TITLE
Home screen shortcuts.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -32,5 +32,17 @@
 
 		<provider android:name="HistoryProvider" 
 				  android:authorities="net.mafro.android.wakeonlan.historyprovider" />
+		<receiver android:name="WidgetProvider" >
+		    <intent-filter>
+		        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+		    </intent-filter>
+		    <meta-data android:name="android.appwidget.provider"
+		               android:resource="@xml/widget_info" />
+		</receiver>
+		<activity android:name=".WidgetConfigure">
+		    <intent-filter>
+    		        <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE"/>
+    		    </intent-filter>
+		</activity> 
 	</application>
 </manifest> 

--- a/res/layout/history_list.xml
+++ b/res/layout/history_list.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/historyview"
+	android:orientation="vertical"
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent">
+	
+	<ListView 
+		android:id="@+id/history"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:layout_weight="1" />
+</LinearLayout>

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -18,18 +18,8 @@
 			android:layout_width="fill_parent"
 			android:layout_height="fill_parent">
 
-			<LinearLayout
-				android:id="@+id/historyview"
-				android:orientation="vertical"
-				android:layout_width="fill_parent"
-				android:layout_height="fill_parent">
-				
-				<ListView 
-					android:id="@+id/history"
-					android:layout_width="fill_parent"
-					android:layout_height="wrap_content"
-					android:layout_weight="1" />
-			</LinearLayout>
+			<include
+				layout="@layout/history_list" />
 			
 			<ScrollView
 				android:id="@+id/wakeview"

--- a/res/layout/widget.xml
+++ b/res/layout/widget.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:orientation="vertical"
+	android:gravity="center|center_vertical"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:padding="3dp">
+
+	<ImageButton
+		android:id="@+id/appwidget_button"
+    		android:layout_width="wrap_content"
+   		android:layout_height="wrap_content"
+		android:src="@drawable/icon"
+		android:background="@null"
+	/>
+
+	<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+		android:id="@+id/appwidget_text"
+	    	android:layout_width="wrap_content"
+	    	android:layout_height="wrap_content"
+	    	android:textAlignment="center"
+	    	android:gravity="center_horizontal|center_vertical"
+	/>
+</LinearLayout>

--- a/res/layout/widget_configure.xml
+++ b/res/layout/widget_configure.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+android:layout_width="match_parent"
+android:layout_height="match_parent"
+android:orientation="horizontal"
+>
+   <include
+	   layout="@layout/history_list" />
+</LinearLayout>
+
+

--- a/res/xml/widget_info.xml
+++ b/res/xml/widget_info.xml
@@ -1,0 +1,8 @@
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="50dp"
+    android:minHeight="50dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget"
+    android:resizeMode="horizontal|vertical"
+    android:configure="net.mafro.android.wakeonlan.WidgetConfigure"> 
+</appwidget-provider>

--- a/src/net/mafro/android/wakeonlan/HistoryListClickListener.java
+++ b/src/net/mafro/android/wakeonlan/HistoryListClickListener.java
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2013 Yohan Pereira.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the author nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package net.mafro.android.wakeonlan;
+
+/**
+ * @desc HistoryListClickListener defines the interface for an object that listens to 
+ *	 onClick events on the HistoryList.
+ */
+
+interface HistoryListClickListener {
+
+	/**
+	 * called whenever an item is clicked
+	 * @param item HistoryItem that was clicked.
+	 */
+	void onClick(HistoryItem item);
+
+}

--- a/src/net/mafro/android/wakeonlan/HistoryListHandler.java
+++ b/src/net/mafro/android/wakeonlan/HistoryListHandler.java
@@ -129,7 +129,10 @@ public class HistoryListHandler implements OnItemClickListener
 	public HistoryItem getItem(int position)
 	{
 		this.cursor.moveToPosition(position);
+		return getItem(this.cursor);
+	}
 
+	public static HistoryItem getItem(Cursor cursor) {
 		int idColumn = cursor.getColumnIndex(History.Items._ID);
 		int titleColumn = cursor.getColumnIndex(History.Items.TITLE);
 		int macColumn = cursor.getColumnIndex(History.Items.MAC);
@@ -137,6 +140,7 @@ public class HistoryListHandler implements OnItemClickListener
 		int portColumn = cursor.getColumnIndex(History.Items.PORT);
 
 		return new HistoryItem(cursor.getInt(idColumn), cursor.getString(titleColumn), cursor.getString(macColumn), cursor.getString(ipColumn), cursor.getInt(portColumn));
+
 	}
 
 

--- a/src/net/mafro/android/wakeonlan/HistoryListHandler.java
+++ b/src/net/mafro/android/wakeonlan/HistoryListHandler.java
@@ -63,7 +63,7 @@ public class HistoryListHandler implements OnItemClickListener
 	private List<HistoryListClickListener> listeners;
 
 
-	private static final String[] PROJECTION = new String[]
+	public static final String[] PROJECTION = new String[]
 	{
 		History.Items._ID,
 		History.Items.TITLE,

--- a/src/net/mafro/android/wakeonlan/HistoryListHandler.java
+++ b/src/net/mafro/android/wakeonlan/HistoryListHandler.java
@@ -1,5 +1,6 @@
 /*
 Copyright (C) 2008-2012 Matt Black.
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,6 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package net.mafro.android.wakeonlan;
 
+import android.app.Activity;
+
 import android.content.ContentValues;
 
 import android.database.Cursor;
@@ -42,6 +45,9 @@ import android.view.View;
 
 import android.net.Uri;
 
+import java.util.List;
+import java.util.ArrayList;
+
 
 /**
  *	@desc	Class handles all functions of the history ListView
@@ -51,9 +57,11 @@ public class HistoryListHandler implements OnItemClickListener
 
 	public static final String TAG = "HistoryListHandler";
 
-	private WakeOnLanActivity wol;
+	private Activity parent;
 	private Cursor cursor;
 	private HistoryAdapter adapter;
+	private List<HistoryListClickListener> listeners;
+
 
 	private static final String[] PROJECTION = new String[]
 	{
@@ -70,10 +78,11 @@ public class HistoryListHandler implements OnItemClickListener
 	private ListView view = null;
 
 
-	public HistoryListHandler(WakeOnLanActivity wol, ListView view)
+	public HistoryListHandler(Activity parent, ListView view)
 	{
-		this.wol = wol;
+		this.parent = parent;
 		this.view = view;
+		this.listeners = new ArrayList<HistoryListClickListener>();
 	}
 
 	public void bind(int sort_mode)
@@ -92,8 +101,8 @@ public class HistoryListHandler implements OnItemClickListener
 		}
 
 		//load History cursor via custom ResourceAdapter
-		cursor = wol.getContentResolver().query(History.Items.CONTENT_URI, PROJECTION, null, null, orderBy);
-		adapter = new HistoryAdapter(wol, cursor);
+		cursor = parent.getContentResolver().query(History.Items.CONTENT_URI, PROJECTION, null, null, orderBy);
+		adapter = new HistoryAdapter(parent, cursor);
 
 		//register self as listener for item clicks
 		view.setOnItemClickListener(this);
@@ -103,16 +112,17 @@ public class HistoryListHandler implements OnItemClickListener
 	}
 
 
-	public void onItemClick(AdapterView parent, View v, int position, long id)
+	public void onItemClick(AdapterView av, View v, int position, long id)
 	{
 		if(position >= 0) {
 			//extract item at position of click
 			HistoryItem item = getItem(position);
 
-			//update used count in DB
-			if(wol.sendPacket(item) != null) {
-				incrementHistory(id);
+			//Fire onClick event to HistoryListListeners
+			for(HistoryListClickListener l : listeners) {
+				l.onClick(item);
 			}
+			
 		}
 	}
 
@@ -155,7 +165,7 @@ public class HistoryListHandler implements OnItemClickListener
 			values.put(History.Items.MAC, mac);
 			values.put(History.Items.IP, ip);
 			values.put(History.Items.PORT, port);
-			wol.getContentResolver().insert(History.Items.CONTENT_URI, values);
+			this.parent.getContentResolver().insert(History.Items.CONTENT_URI, values);
 		}
 	}
 
@@ -168,7 +178,7 @@ public class HistoryListHandler implements OnItemClickListener
 		values.put(History.Items.PORT, port);
 
 		Uri itemUri = Uri.withAppendedPath(History.Items.CONTENT_URI, Integer.toString(id));
-		wol.getContentResolver().update(itemUri, values, null, null);
+		this.parent.getContentResolver().update(itemUri, values, null, null);
 	}
 
 	public void incrementHistory(long id)
@@ -181,14 +191,22 @@ public class HistoryListHandler implements OnItemClickListener
 		values.put(History.Items.LAST_USED_DATE, Long.valueOf(System.currentTimeMillis()));
 
 		Uri itemUri = Uri.withAppendedPath(History.Items.CONTENT_URI, Long.toString(id));
-		wol.getContentResolver().update(itemUri, values, null, null);
+		this.parent.getContentResolver().update(itemUri, values, null, null);
 	}
 
 	public void deleteHistory(int id)
 	{
 		//use HistoryProvider to remove this row
 		Uri itemUri = Uri.withAppendedPath(History.Items.CONTENT_URI, Integer.toString(id));
-		wol.getContentResolver().delete(itemUri, null, null);
+		this.parent.getContentResolver().delete(itemUri, null, null);
+	}
+
+	public void addHistoryListClickListener(HistoryListClickListener l) {
+		this.listeners.add(l);
+	}
+	
+	public void removeHistoryListClickListener(HistoryListClickListener l) {
+		this.listeners.remove(l);
 	}
 
 }

--- a/src/net/mafro/android/wakeonlan/WakeOnLanActivity.java
+++ b/src/net/mafro/android/wakeonlan/WakeOnLanActivity.java
@@ -276,7 +276,7 @@ public class WakeOnLanActivity extends Activity implements OnClickListener, OnTa
 			//check for edit mode - no send of packet
 			if(_editModeID == 0) {
 				//send the magic packet
-				String formattedMac = sendPacket(title, mac, ip, port);
+				String formattedMac = sendPacket(WakeOnLanActivity.this, title, mac, ip, port);
 
 				//on successful send, add to history list
 				if(formattedMac != null) {
@@ -393,10 +393,10 @@ public class WakeOnLanActivity extends Activity implements OnClickListener, OnTa
 
 	public String sendPacket(HistoryItem item)
 	{
-		return sendPacket(item.title, item.mac, item.ip, item.port);
+		return sendPacket(WakeOnLanActivity.this, item.title, item.mac, item.ip, item.port);
 	}
 
-	public String sendPacket(String title, String mac, String ip, int port)
+	public static String sendPacket(Context context,String title, String mac, String ip, int port)
 	{
 		String formattedMac = null;
 
@@ -404,16 +404,16 @@ public class WakeOnLanActivity extends Activity implements OnClickListener, OnTa
 			formattedMac = MagicPacket.send(mac, ip, port);
 
 		}catch(IllegalArgumentException iae) {
-			notifyUser(getString(R.string.send_failed)+":\n"+iae.getMessage(), WakeOnLanActivity.this);
+			notifyUser(context.getString(R.string.send_failed)+":\n"+iae.getMessage(), context);
 			return null;
 
 		}catch(Exception e) {
-			notifyUser(getString(R.string.send_failed), WakeOnLanActivity.this);
+			notifyUser(context.getString(R.string.send_failed), context);
 			return null;
 		}
 
 		//display sent message to user
-		notifyUser(getString(R.string.packet_sent)+" to "+title, WakeOnLanActivity.this);
+		notifyUser(context.getString(R.string.packet_sent)+" to "+title, context);
 		return formattedMac;
 	}
 

--- a/src/net/mafro/android/wakeonlan/WakeOnLanActivity.java
+++ b/src/net/mafro/android/wakeonlan/WakeOnLanActivity.java
@@ -172,6 +172,14 @@ public class WakeOnLanActivity extends Activity implements OnClickListener, OnTa
 		//load history handler (deals with cursor and history ListView)
 		histHandler = new HistoryListHandler(this, lv);
 		histHandler.bind(sort_mode);
+		
+		//add listener to get on click events
+		histHandler.addHistoryListClickListener(new HistoryListClickListener() {
+
+			public void onClick(HistoryItem item) {
+				onHistoryItemClick(item);
+			}
+		});
 
 		//register main Activity as context menu handler
 		registerForContextMenu(lv);
@@ -476,6 +484,12 @@ public class WakeOnLanActivity extends Activity implements OnClickListener, OnTa
 		}
 	}
 
+	private void onHistoryItemClick(HistoryItem item) {
+		String mac = sendPacket(item);
+		if(mac != null) {
+			histHandler.incrementHistory(item.id);
+		}
+	}
 
 	public static void notifyUser(String message, Context context)
 	{

--- a/src/net/mafro/android/wakeonlan/WidgetConfigure.java
+++ b/src/net/mafro/android/wakeonlan/WidgetConfigure.java
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2013 Yohan Pereira.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the author nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+package net.mafro.android.wakeonlan;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+
+import android.appwidget.AppWidgetManager;
+
+import android.os.Bundle;
+
+import android.view.View;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.Context;
+
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.RemoteViews;
+
+/**
+ * @desc This class is used to configure the home screen widget.
+ */
+public class WidgetConfigure extends Activity
+{
+	private HistoryListHandler historyListHandler;
+	private int widget_id;
+	private SharedPreferences settings;
+
+
+	@Override
+	public void onCreate(Bundle savedInstanceState)
+	{
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.widget_configure);
+		ListView lv = (ListView)findViewById(R.id.history);
+		historyListHandler = new HistoryListHandler(this, lv);
+
+		settings = getSharedPreferences(WakeOnLanActivity.TAG, 0);
+		int sort_mode = settings.getInt("sort_mode", WakeOnLanActivity.CREATED);
+		historyListHandler.bind(sort_mode);
+		//Add on click listener
+		historyListHandler.addHistoryListClickListener(new HistoryListClickListener () {
+
+			public void onClick(HistoryItem item) {
+				selected(item);
+			}
+		});
+
+		//get the widget id
+		Intent intent = getIntent();
+		widget_id = WidgetProvider.getWidgetId(intent);
+
+		if(widget_id == AppWidgetManager.INVALID_APPWIDGET_ID) {
+			//No valid widget id .. bailling.
+			finish();
+		}
+
+	}
+
+	private void selected(HistoryItem item) {
+		// save selected item id to the settings.
+		WidgetProvider.saveItemPref(settings, item, widget_id);	
+
+		// configure the widget
+		WidgetProvider.configureWidget(widget_id, item, this);
+
+		//return result
+		Intent resultValue = new Intent();
+		resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widget_id);
+            	setResult(RESULT_OK, resultValue);
+            	finish();
+
+	}
+
+	
+	
+}

--- a/src/net/mafro/android/wakeonlan/WidgetProvider.java
+++ b/src/net/mafro/android/wakeonlan/WidgetProvider.java
@@ -60,20 +60,28 @@ public class WidgetProvider extends AppWidgetProvider {
 	private SharedPreferences settings;
 
 	public WidgetProvider() {
-		Cursor cursor;
 		//Need a context to initlise this.
 		settings = null;
 	}
 
-	public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+	/**
+	 * @desc Called when an instance of this class is activated. Do init stuff here
+	 */
+	@overide
+	public void onEnabled(Context context) {
 		if(settings == null) {
 			settings = context.getSharedPreferences(WakeOnLanActivity.TAG, 0);
 		}
+	}
 
-		// Perform this loop procedure for each widget.
+	/**
+	 * @desc this method is called once when the WidgetHost starts (usually when the OS boots).
+	 */
+	@overide
+	public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+
 		final int N = appWidgetIds.length;
 		for (int i=0; i<N; i++) {
-			//TODO initlise the widget here.
 			int widget_id = appWidgetIds[i];
 			
 			
@@ -90,11 +98,6 @@ public class WidgetProvider extends AppWidgetProvider {
 	public void onReceive(Context context, Intent intent) {
 		//
 		super.onReceive(context, intent);
-		Log.v(WakeOnLanActivity.TAG, "in onReceive");
-
-		if(settings == null) {
-			settings = context.getSharedPreferences(WakeOnLanActivity.TAG, 0);
-		}
 
 		if (intent.getAction().startsWith(WIDGET_ONCLICK)) {
 
@@ -107,6 +110,7 @@ public class WidgetProvider extends AppWidgetProvider {
 			//get the HistoryItem associated with the widget_id.
 			HistoryItem item = loadItemPref(context, settings, widget_id);
 
+			//send the packet.
 			WakeOnLanActivity.sendPacket(context, 
 						     item.title, 
 						     item.mac, 
@@ -115,6 +119,13 @@ public class WidgetProvider extends AppWidgetProvider {
 		}
 	}
 
+	@Override
+	public void onDelete(Context context, int[] id) {
+		final int N = appWidgetIds.length;
+		for (int i=0; i<N; i++) {
+			deleteItemPref(settings, id[N]);
+		}
+	}
 
 	/**
 	 * @desc gets the widget id from an intent.
@@ -170,6 +181,12 @@ public class WidgetProvider extends AppWidgetProvider {
 		editor.commit();
 	}
 
+	public static void deleteItemPref(SharedPreferences settings, int widget_id) {
+		SharedPreferences.Editor editor = settings.edit();
+		editor.remove(SETTINGS_PREFIX + widget_id);
+		editor.commit();
+	}
+
 	/**
 	 * @desc load the HistoryItem associated with a widget_id.
 	 */
@@ -189,7 +206,7 @@ public class WidgetProvider extends AppWidgetProvider {
 					null, null);
 		if(cursor.getCount() == 0) {
 			//item_id does not exists anymore
-			//TODO delete the prefrence.
+			//TODO copy the item details so that we dont have to worry about this.
 			return null;
 		}
 		cursor.moveToFirst();

--- a/src/net/mafro/android/wakeonlan/WidgetProvider.java
+++ b/src/net/mafro/android/wakeonlan/WidgetProvider.java
@@ -48,7 +48,6 @@ import android.util.Log;
 
 /**
  * @desc This class is used to setup the home screen widget, as well as handle click events
- * @rename WidgetProvider
  */
 
 //TODO handle deletion of widgets.

--- a/src/net/mafro/android/wakeonlan/WidgetProvider.java
+++ b/src/net/mafro/android/wakeonlan/WidgetProvider.java
@@ -65,27 +65,28 @@ public class WidgetProvider extends AppWidgetProvider {
 	/**
 	 * @desc Called when an instance of this class is activated. Do init stuff here
 	 */
-	@overide
+	@Override
 	public void onEnabled(Context context) {
-		if(settings == null) {
-			settings = context.getSharedPreferences(WakeOnLanActivity.TAG, 0);
-		}
+		//FIXME does not seem to have any effect.
+		//initSettings(context);	
 	}
 
 	/**
 	 * @desc this method is called once when the WidgetHost starts (usually when the OS boots).
 	 */
-	@overide
+	@Override
 	public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+	
+		initSettings(context);	
 
 		final int N = appWidgetIds.length;
 		for (int i=0; i<N; i++) {
 			int widget_id = appWidgetIds[i];
 			
-			
 			HistoryItem item = loadItemPref(context, settings, widget_id);
 			if(item == null) { // item or prefrences missing.
-				//TODO delete the widget probably.
+				//TODO delete the widget probably (cant find a way to do this).
+				//maybe set the title of the widget to ERROR 
 				continue;
 			}
 			configureWidget(widget_id, item, context);
@@ -97,6 +98,7 @@ public class WidgetProvider extends AppWidgetProvider {
 		//
 		super.onReceive(context, intent);
 
+		initSettings(context);	
 		if (intent.getAction().startsWith(WIDGET_ONCLICK)) {
 
 			//get the widget id
@@ -118,10 +120,11 @@ public class WidgetProvider extends AppWidgetProvider {
 	}
 
 	@Override
-	public void onDelete(Context context, int[] id) {
-		final int N = appWidgetIds.length;
+	public void onDeleted(Context context, int[] id) {
+		initSettings(context);	
+		final int N = id.length;
 		for (int i=0; i<N; i++) {
-			deleteItemPref(settings, id[N]);
+			deleteItemPref(settings, id[i]);
 		}
 	}
 
@@ -161,7 +164,6 @@ public class WidgetProvider extends AppWidgetProvider {
 	
 
 	private static  PendingIntent getPendingSelfIntent(Context context, int widget_id, String action) {
-		//TODO try and set the widget id here. (not sure what this means anymore).
 		Intent intent = new Intent(context, WidgetProvider.class);
 		intent.setAction(action);
 		Bundle bundle = new Bundle();
@@ -211,6 +213,12 @@ public class WidgetProvider extends AppWidgetProvider {
 		HistoryItem item = HistoryListHandler.getItem(cursor);
 		return item;
 
+	}
+
+	private void initSettings(Context context) {
+		if(settings == null) {
+			settings = context.getSharedPreferences(WakeOnLanActivity.TAG, 0);
+		}
 	}
 	
 }

--- a/src/net/mafro/android/wakeonlan/WidgetProvider.java
+++ b/src/net/mafro/android/wakeonlan/WidgetProvider.java
@@ -50,8 +50,6 @@ import android.util.Log;
  * @desc This class is used to setup the home screen widget, as well as handle click events
  */
 
-//TODO handle deletion of widgets.
-
 public class WidgetProvider extends AppWidgetProvider {
 
 	public static final String SETTINGS_PREFIX="widget_";

--- a/src/net/mafro/android/wakeonlan/WidgetProvider.java
+++ b/src/net/mafro/android/wakeonlan/WidgetProvider.java
@@ -1,0 +1,202 @@
+/*
+Copyright (C) 2013 Yohan Pereira.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the author nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+package net.mafro.android.wakeonlan;
+
+
+import android.app.PendingIntent;
+
+import android.database.Cursor;
+
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+
+import android.content.Intent;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import android.os.Bundle;
+
+import android.widget.RemoteViews;
+import android.util.Log;
+
+/**
+ * @desc This class is used to setup the home screen widget, as well as handle click events
+ * @rename WidgetProvider
+ */
+
+//TODO handle deletion of widgets.
+
+public class WidgetProvider extends AppWidgetProvider {
+
+	public static final String SETTINGS_PREFIX="widget_";
+	public static final String WIDGET_ONCLICK="net.mafro.android.wakeonlan.WidgetOnClick";
+
+	private SharedPreferences settings;
+
+	public WidgetProvider() {
+		Cursor cursor;
+		//Need a context to initlise this.
+		settings = null;
+	}
+
+	public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+		if(settings == null) {
+			settings = context.getSharedPreferences(WakeOnLanActivity.TAG, 0);
+		}
+
+		// Perform this loop procedure for each widget.
+		final int N = appWidgetIds.length;
+		for (int i=0; i<N; i++) {
+			//TODO initlise the widget here.
+			int widget_id = appWidgetIds[i];
+			
+			
+			HistoryItem item = loadItemPref(context, settings, widget_id);
+			if(item == null) { // item or prefrences missing.
+				//TODO delete the widget probably.
+				continue;
+			}
+			configureWidget(widget_id, item, context);
+		}
+	}
+
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		//
+		super.onReceive(context, intent);
+		Log.v(WakeOnLanActivity.TAG, "in onReceive");
+
+		if(settings == null) {
+			settings = context.getSharedPreferences(WakeOnLanActivity.TAG, 0);
+		}
+
+		if (intent.getAction().startsWith(WIDGET_ONCLICK)) {
+
+			//get the widget id
+			int widget_id = getWidgetId(intent);
+			if(widget_id == AppWidgetManager.INVALID_APPWIDGET_ID) {
+				return;
+			}
+			
+			//get the HistoryItem associated with the widget_id.
+			HistoryItem item = loadItemPref(context, settings, widget_id);
+
+			WakeOnLanActivity.sendPacket(context, 
+						     item.title, 
+						     item.mac, 
+						     item.ip, 
+						     item.port);
+		}
+	}
+
+
+	/**
+	 * @desc gets the widget id from an intent.
+	 */
+	public static int getWidgetId(Intent intent) {
+		Bundle extras = intent.getExtras();
+		int _widget_id = AppWidgetManager.INVALID_APPWIDGET_ID;
+		if (extras != null) {
+			_widget_id = extras.getInt(
+					AppWidgetManager.EXTRA_APPWIDGET_ID, 
+					AppWidgetManager.INVALID_APPWIDGET_ID);
+
+		}
+		return _widget_id;	
+	}
+
+	/**
+	 * @desc configures a widget for the first time. Usually called when creating a widget
+	 *	 for the first time or initlising existing widgets when the AppWidgetManager 
+	 *	restarts (usually when the phone reboots).
+	 */
+	public static void configureWidget(int widget_id, HistoryItem item, Context context) {
+
+		RemoteViews views = new RemoteViews(context.getPackageName(),
+		R.layout.widget);
+		views.setTextViewText(R.id.appwidget_text, item.title);
+		//FIXME hack : append id to action  to prevent clearing the extras bundle. 
+		views.setOnClickPendingIntent(R.id.appwidget_button, getPendingSelfIntent(context, widget_id, WIDGET_ONCLICK + widget_id));
+
+		//tell the widget manager
+		AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+		appWidgetManager.updateAppWidget(widget_id, views);
+	}
+	
+	
+
+	private static  PendingIntent getPendingSelfIntent(Context context, int widget_id, String action) {
+		//TODO try and set the widget id here. (not sure what this means anymore).
+		Intent intent = new Intent(context, WidgetProvider.class);
+		intent.setAction(action);
+		Bundle bundle = new Bundle();
+		bundle.putInt(AppWidgetManager.EXTRA_APPWIDGET_ID, widget_id);
+		intent.putExtras(bundle);
+		return PendingIntent.getBroadcast(context, 0, intent, 0);
+	}
+	
+	/**
+	 * @desc saves the given history item/widget_id combination.
+	 */
+	public static void saveItemPref(SharedPreferences settings, HistoryItem item, int widget_id) {
+		SharedPreferences.Editor editor = settings.edit();
+		editor.putInt(SETTINGS_PREFIX + widget_id, item.id);
+		editor.commit();
+	}
+
+	/**
+	 * @desc load the HistoryItem associated with a widget_id.
+	 */
+	public static HistoryItem loadItemPref(Context context, SharedPreferences settings, int widget_id) {
+		//get item_id
+		int item_id = settings.getInt(SETTINGS_PREFIX + widget_id, -1);
+		if(item_id == -1) {
+			//No item_id found for given widget return null.
+			return null;
+		}
+
+		//Create HistoryItem
+		Cursor cursor = context.getContentResolver()
+				.query(History.Items.CONTENT_URI, 
+					HistoryListHandler.PROJECTION, 
+					History.Items._ID +" = "+item_id,
+					null, null);
+		if(cursor.getCount() == 0) {
+			//item_id does not exists anymore
+			//TODO delete the prefrence.
+			return null;
+		}
+		cursor.moveToFirst();
+		HistoryItem item = HistoryListHandler.getItem(cursor);
+		return item;
+
+	}
+	
+}

--- a/src/net/mafro/android/wakeonlan/WidgetProvider.java
+++ b/src/net/mafro/android/wakeonlan/WidgetProvider.java
@@ -68,7 +68,7 @@ public class WidgetProvider extends AppWidgetProvider {
 	@Override
 	public void onEnabled(Context context) {
 		//FIXME does not seem to have any effect.
-		//initSettings(context);	
+		//initSettings(context);
 	}
 
 	/**
@@ -77,7 +77,7 @@ public class WidgetProvider extends AppWidgetProvider {
 	@Override
 	public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
 	
-		initSettings(context);	
+		initSettings(context);
 
 		final int N = appWidgetIds.length;
 		for (int i=0; i<N; i++) {
@@ -86,7 +86,7 @@ public class WidgetProvider extends AppWidgetProvider {
 			HistoryItem item = loadItemPref(context, settings, widget_id);
 			if(item == null) { // item or prefrences missing.
 				//TODO delete the widget probably (cant find a way to do this).
-				//maybe set the title of the widget to ERROR 
+				//maybe set the title of the widget to ERROR
 				continue;
 			}
 			configureWidget(widget_id, item, context);
@@ -98,7 +98,7 @@ public class WidgetProvider extends AppWidgetProvider {
 		//
 		super.onReceive(context, intent);
 
-		initSettings(context);	
+		initSettings(context);
 		if (intent.getAction().startsWith(WIDGET_ONCLICK)) {
 
 			//get the widget id
@@ -121,7 +121,7 @@ public class WidgetProvider extends AppWidgetProvider {
 
 	@Override
 	public void onDeleted(Context context, int[] id) {
-		initSettings(context);	
+		initSettings(context);
 		final int N = id.length;
 		for (int i=0; i<N; i++) {
 			deleteItemPref(settings, id[i]);
@@ -177,13 +177,23 @@ public class WidgetProvider extends AppWidgetProvider {
 	 */
 	public static void saveItemPref(SharedPreferences settings, HistoryItem item, int widget_id) {
 		SharedPreferences.Editor editor = settings.edit();
+
+		//store HistoryItem details in settings
 		editor.putInt(SETTINGS_PREFIX + widget_id, item.id);
+		editor.putString(SETTINGS_PREFIX + widget_id + History.Items.TITLE, item.title);
+		editor.putString(SETTINGS_PREFIX + widget_id + History.Items.MAC, item.mac);
+		editor.putString(SETTINGS_PREFIX + widget_id + History.Items.IP, item.ip);
+		editor.putInt(SETTINGS_PREFIX + widget_id + History.Items.PORT, item.port);
 		editor.commit();
 	}
 
 	public static void deleteItemPref(SharedPreferences settings, int widget_id) {
 		SharedPreferences.Editor editor = settings.edit();
 		editor.remove(SETTINGS_PREFIX + widget_id);
+		editor.remove(SETTINGS_PREFIX + widget_id + History.Items.TITLE);
+		editor.remove(SETTINGS_PREFIX + widget_id + History.Items.MAC);
+		editor.remove(SETTINGS_PREFIX + widget_id + History.Items.IP);
+		editor.remove(SETTINGS_PREFIX + widget_id + History.Items.PORT);
 		editor.commit();
 	}
 
@@ -198,19 +208,13 @@ public class WidgetProvider extends AppWidgetProvider {
 			return null;
 		}
 
-		//Create HistoryItem
-		Cursor cursor = context.getContentResolver()
-				.query(History.Items.CONTENT_URI, 
-					HistoryListHandler.PROJECTION, 
-					History.Items._ID +" = "+item_id,
-					null, null);
-		if(cursor.getCount() == 0) {
-			//item_id does not exists anymore
-			//TODO copy the item details so that we dont have to worry about this.
-			return null;
-		}
-		cursor.moveToFirst();
-		HistoryItem item = HistoryListHandler.getItem(cursor);
+		//TODO check for invalid values.
+		String title = settings.getString(SETTINGS_PREFIX + widget_id + History.Items.TITLE, "");
+		String mac = settings.getString(SETTINGS_PREFIX + widget_id + History.Items.MAC, "");
+		String ip = settings.getString(SETTINGS_PREFIX + widget_id + History.Items.IP, "");
+		int port = settings.getInt(SETTINGS_PREFIX + widget_id + History.Items.PORT, -1);
+
+		HistoryItem item = new HistoryItem(item_id, title, mac, ip, port);
 		return item;
 
 	}


### PR DESCRIPTION
There's one issue that needs to be ironed out. Once the user creates a shortcut
to a HistoryItem and later modifies the HistoryItem via the application,
the shortcut is not updated.

Initially this wasn't an issue because each Shortcut was associated with
a HistoryItem id so the values were read directly from the database
every time the shortcut was triggered. However if the user deletes the
said HistoryItem this would leave the shortcut in an invalid state. 

To avoid this in my last commit I resorted to copying over the needed
details of the selected HistoryItem to the Shared Preferences of the
shortcut and hence if the original HistoryItem is modified the shorcut
is not changed.
